### PR TITLE
Fix nil filename error

### DIFF
--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -27,7 +27,7 @@ M.projects = function ()
     for _, v in pairs(file_list) do
         local project_name = string.gsub(v, projects_dir .. '/', '')
         project_name = string.match(project_name, '^.+/')
-        if added_files[project_name] == nil then
+        if project_name ~= nil and added_files[project_name] == nil then
             added_files[project_name] = project_name
             results[i] = project_name
             i = i + 1


### PR DESCRIPTION
Ran into an issue where the first file it was reading had a nil filename. The issue was with line 31 specifically, so I added a check. There could be a better reason for it breaking and a better fix but seemed like more trouble to figure out than to just add the check.

```lua
added_files[project_name] = project_name // table index is nil
```